### PR TITLE
Tweak spherical norm coefficients

### DIFF
--- a/docs/src/man/usage.md
+++ b/docs/src/man/usage.md
@@ -83,7 +83,7 @@ defined as
 computing the normalization separately from the function:
 ```jldoctest PlmUsage
 julia> λlm(157, 150, 0.5)
-1.977888411320258e-5
+1.977888411320263e-5
 ```
 
 !!! note


### PR DESCRIPTION
The first commit simply eliminates a few unwanted instructions.
* Using `@fastmath(sqrt)` gets rid of the domain checking that the argument is positive, which eliminates one branch from the fast path.
* Multiplying by an inverse is changed to a division, which saves one floating point operation.

The second commit is more subtle. The expression for the μ_ℓ coefficient in the spherical normalization is modified to gain a few ulps of accuracy across what is probably the entire practical domain of degrees (ℓ). (N.B. the `muladd` subexpression does _not_ need to be an FMA to maintain accuracy, but FMA is allowed if it is more efficient.)

Before:
```julia
julia> f1(l) = Legendre.Plm_μ(LegendreSphereNorm(), Float64, l);

julia> f2(l) = Float64(Legendre.Plm_μ(LegendreSphereNorm(), BigFloat, l));

julia> Δ(l) = f1(l) - f2(l);

julia> findfirst(!=(0), Δ.(1:500_000))
11
```

With this PR:
```julia
julia> findfirst(!=(0), Δ.(1:500_000))
31722
```