### PR TITLE
Calculate the initial condition using only real numbers

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017–2021: Justin Willmert
+Copyright (c) 2017–2022: Justin Willmert
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AssociatedLegendrePolynomials"
 uuid = "2119f1ac-fb78-50f5-8cc0-dda848ebdb19"
 authors = ["Justin Willmert <justin@willmert.me>"]
-version = "1.0.0"
+version = "1.0.1"
 
 [compat]
 julia = "1.2"

--- a/src/calculation.jl
+++ b/src/calculation.jl
@@ -137,7 +137,7 @@ _fma(x, y, z) = Base.fma(x, y, z)
         y¹[ii] = sqrt(y²[ii])
     end
 
-    fill!(pm, initcond(norm, T))
+    fill!(pm, initcond(norm, real(T)))
     for m in 0:mmax
         @simd for ii in I
             if N == 2


### PR DESCRIPTION
The other recursion coefficients were already all using only real number types, but the initial condition was forgotten. This has worked thus far, but a change in the upcoming Julia v1.9 (presumably JuliaLang/julia#47255) broke the exact correspondance between real inputs and real-axis complex inputs for the spherical normalization.

Specifically, on Julia 1.8:
```julia
julia> r = inv(sqrt(4convert(Float64, π)))
0.28209479177387814

julia> r - real(inv(sqrt(4convert(ComplexF64, π))))
0.0
```
while with Julia 1.9:
```julia
julia> r = inv(sqrt(4convert(Float64, π)))
0.28209479177387814

julia> r - real(inv(sqrt(4convert(ComplexF64, π))))
-5.551115123125783e-17
```

The simple change that allows the tests to pass again is to just ask for the initial condition to be calculated in the appropriate real number type.