### PR TITLE
Update to testing with minimum package version on minimum Julia

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,9 +28,9 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.2'     # earliest supported
+          - 'min'     # earliest supported
           - '1'       # latest release
-          - 'nightly'
+          - 'pre'
         os:
           - ubuntu-latest
         arch:
@@ -42,10 +42,12 @@ jobs:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v2
+      - uses: julia-actions/julia-downgrade-compat@v1
+        if: ${{ contains(fromJSON('["min"]'), matrix.version) }}
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: lcov.info


### PR DESCRIPTION
This has no material impact on this package since it has no external dependencies, but it aligns the CI script with what I use elsewhere (for ease of maintenance and consistency).